### PR TITLE
Convert to flask-restful structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .venv/
-
+venv
 *.pyc
 __pycache__/
 

--- a/mj-flask/app.py
+++ b/mj-flask/app.py
@@ -1,32 +1,21 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, make_response
+from flask_restful import Resource, Api
 from dotenv import load_dotenv
-from code_helper import add_full_stops_to_comments
 import os
 
+from resources.hello import HelloWorld
+from resources.add_comments import AddFullStopsToComments
+
 app = Flask(__name__)
+api = Api(app)
 
 # Build a path and import the environment variables.
-current_dir = os.path.dirname(os.path.abspath(__file__))
-project_dir = os.path.abspath(os.path.join(current_dir, os.pardir))
-file_path = os.path.join(project_dir, ".env")
-load_dotenv(file_path)
+dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
+load_dotenv(dotenv_path)
 
-
-@app.route('/')
-def hello_world():  # put application's code here
-    return 'Hello World!\n\nYou are probably looking for the /add-full-stops-to-comments API champ.'
-
-
-@app.route('/add-full-stops-to-comments', methods=['GET', 'POST'])
-def add_full_stops_comments():
-    """Take in code, add full stops to the end of comment lines."""
-    if request.method == "POST":
-        input_code = request.form.get('input_code')
-        modified_code = add_full_stops_to_comments(input_code)
-        return render_template('code_comparison.html', original_code=input_code, modified_code=modified_code)
-    else:
-        return render_template("submit_code.html")
-
+# Import the resources and declare api endpoints.
+api.add_resource(HelloWorld, '/')
+api.add_resource(AddFullStopsToComments, '/add-full-stops-to-comments')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/mj-flask/resources/add_comments.py
+++ b/mj-flask/resources/add_comments.py
@@ -1,0 +1,14 @@
+from flask_restful import Resource
+from flask import Flask, request, render_template, make_response
+from code_helper import add_full_stops_to_comments
+
+class AddFullStopsToComments(Resource):
+    def get(self):
+        headers = {'Content-Type': 'text/html'}
+        return make_response(render_template("submit_code.html"), 200, headers)
+    
+    def post(self):
+        input_code = request.form.get('input_code')
+        modified_code = add_full_stops_to_comments(input_code)
+        headers = {'Content-Type': 'text/html'}
+        return make_response(render_template('code_comparison.html', original_code=input_code, modified_code=modified_code), 200, headers)

--- a/mj-flask/resources/hello.py
+++ b/mj-flask/resources/hello.py
@@ -1,0 +1,8 @@
+from flask_restful import Resource
+from flask import Flask, request, render_template, make_response
+
+class HelloWorld(Resource):
+    def get(self):
+        headers = {'Content-Type': 'text/html'}
+        message = 'Hello World!<br><br>You are probably looking for the /add-full-stops-to-comments API champ.'
+        return make_response(message, 200, headers)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ charset-normalizer==3.1.0
 click==8.1.3
 colorama==0.4.6
 Flask==2.3.2
+Flask-RESTful==0.3.10
 frozenlist==1.3.3
 idna==3.4
 importlib-metadata==6.6.0


### PR DESCRIPTION
Hey MJ, long time no speak. I decided to pull this together while procrastinating from something else.
It's not necessarily better than what you had but just a good way to see another way of doing it. Using Flask-Restful along with Flask allows you to have a REST first approach, as opposed to a visual/HTML first approach. You'll see this as you need to specify headers etc when returning a html response, which you didn't previously have to do.

The reason I like using this is because it gives you the easy option to do both simply easy REST apis using JSON format but also allows you to return your HTML pages as you did before. Adding endpoints as a resource allows you to have a bit more control over your APIs and you can do some business logic in there also. 

I also made a change to how you were grabbing your .env file just to make it a bit simpler.

Again no issues with what you had it was able to get it working right away but just another way of looking at the problem. I dont expect you to merge the PR, just wanted to share some thoughts with you.

P.S I have a Harry Potter quote API I wrote in Python with Flask-Restful, you can have a look at it if you like to show you how to do some cool stuff like rate-limiting etc. https://github.com/joeltgray/HarryPotterAPI

Hope you're keeping well!